### PR TITLE
Align canonical origin and metadata to https://shubham-mathur.me

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,8 @@
     />
     <meta property="og:title" content="Shubham Mathur | Portfolio" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://shubham-mathur.com/" />
+    <meta property="og:url" content="https://shubham-mathur.me/" />
+    <link rel="canonical" href="https://shubham-mathur.me/" />
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
@@ -56,14 +57,14 @@
         "@context": "https://schema.org/",
         "@type": "Person",
         "name": "Shubham Mathur",
-        "url": "https://shubham-mathur.com/",
-        "image": "https://shubham-mathur.com/static/media/shubham.fad4110b.jpg",
+        "url": "https://shubham-mathur.me/",
+        "image": "https://shubham-mathur.me/static/media/shubham.fad4110b.jpg",
         "sameAs": [
           "https://fb.me/itseasy21",
           "https://instagram.com/itseasy21",
           "https://www.linkedin.com/in/itseasy21?_l=en_US",
           "https://github.com/itseasy21",
-          "https://shubham-mathur.com/"
+          "https://shubham-mathur.me/"
         ],
         "jobTitle": "Technical Lead",
         "worksFor": {


### PR DESCRIPTION
### Motivation
- Ensure the site uses a single canonical production origin so social previews, search engines, and structured data consistently reference `https://shubham-mathur.me/`.
- Remove a stale `.com` reference in page metadata and add an explicit canonical link to avoid duplicate-content issues.

### Description
- Updated `public/index.html` to set Open Graph `og:url` to `https://shubham-mathur.me/` and added `<link rel="canonical" href="https://shubham-mathur.me/" />` in the `<head>`.
- Updated the JSON-LD block in `public/index.html` to use `https://shubham-mathur.me/` for the `url`, `image` host, and the self `sameAs` reference.
- Verified that `public/robots.txt`, `public/sitemap.xml`, and `package.json` already reference the canonical `.me` origin and required no edits.

### Testing
- Searched the repository for domain references with `rg -n "shubham-mathur\.com|shubham-mathur\.me"` and confirmed there are no remaining `.com` references.
- Ran `rg -n "shubham-mathur|http[s]?://|homepage|Sitemap:|og:url|canonical|application/ld+json"` against key public files to validate updated metadata.
- Inspected the updated `public/index.html` with `nl -ba public/index.html` and ran `git status --short` to confirm only the intended file was modified; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d621477f08329b2b625ef143f8715)