### PR TITLE
Improve SEO metadata and add route-aware social tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,33 @@
       name="description"
       content="Full Stack Developer taking websites and apps to the next level of awesomeness globally!"
     />
+    <meta
+      name="robots"
+      content="index,follow,max-image-preview:large"
+    />
     <meta property="og:title" content="Shubham Mathur | Portfolio" />
+    <meta
+      property="og:description"
+      content="Full Stack Developer taking websites and apps to the next level of awesomeness globally!"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://shubham-mathur.me/" />
+    <meta
+      property="og:image"
+      content="https://shubham-mathur.me/social-preview.svg"
+    />
+    <meta property="og:site_name" content="Shubham Mathur Portfolio" />
+    <meta property="og:locale" content="en_US" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Shubham Mathur | Portfolio" />
+    <meta
+      name="twitter:description"
+      content="Full Stack Developer taking websites and apps to the next level of awesomeness globally!"
+    />
+    <meta
+      name="twitter:image"
+      content="https://shubham-mathur.me/social-preview.svg"
+    />
     <link rel="canonical" href="https://shubham-mathur.me/" />
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -70,7 +94,7 @@
         "worksFor": {
           "@type": "Organization",
           "name": "Top Graduates"
-        }  
+        }
       }
       </script>
   </head>

--- a/public/social-preview.svg
+++ b/public/social-preview.svg
@@ -1,0 +1,34 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Shubham Mathur Portfolio Social Preview</title>
+  <desc id="desc">A social preview image with a dark gradient background and branding text for Shubham Mathur's portfolio website.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#090D1F"/>
+      <stop offset="1" stop-color="#1A2B5A"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="157" y1="152" x2="985" y2="522" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8F94FB"/>
+      <stop offset="1" stop-color="#4E54C8"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <circle cx="1080" cy="84" r="142" fill="#4E54C8" fill-opacity="0.25"/>
+  <circle cx="136" cy="548" r="184" fill="#8F94FB" fill-opacity="0.2"/>
+
+  <rect x="157" y="152" width="886" height="326" rx="32" fill="url(#accent)" fill-opacity="0.2" stroke="#8F94FB" stroke-opacity="0.6"/>
+
+  <text x="220" y="267" fill="#FFFFFF" font-family="'Segoe UI', Arial, sans-serif" font-size="62" font-weight="700">
+    Shubham Mathur
+  </text>
+  <text x="220" y="333" fill="#D5DCFF" font-family="'Segoe UI', Arial, sans-serif" font-size="34" font-weight="500">
+    Full Stack Developer · Data Analytics &amp; ETL Expert
+  </text>
+  <text x="220" y="389" fill="#D5DCFF" font-family="'Segoe UI', Arial, sans-serif" font-size="34" font-weight="500">
+    Blockchain Enthusiast
+  </text>
+  <text x="220" y="440" fill="#FFFFFF" font-family="'Segoe UI', Arial, sans-serif" font-size="28" font-weight="600">
+    shubham-mathur.me
+  </text>
+</svg>

--- a/src/pages/contact/ContactComponent.js
+++ b/src/pages/contact/ContactComponent.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import Header from "../../components/header/Header";
 import Footer from "../../components/footer/Footer";
 import SocialMedia from "../../components/socialMedia/SocialMedia";
@@ -10,12 +10,20 @@ import { style } from "glamor";
 import LazyImage from "../../components/LazyImage";
 // Import the image directly
 import profileImage from "../../assests/images/shubham.jpg";
+import usePageMetadata from "../usePageMetadata";
 
 const ContactData = contactPageData.contactSection;
 const blogSection = contactPageData.blogSection;
 
 function Contact(props) {
   const theme = props.theme;
+
+  usePageMetadata({
+    title: "Contact | Shubham Mathur",
+    description:
+      "Get in touch with Shubham Mathur for opportunities, collaborations, and consulting projects.",
+    path: "/contact",
+  });
 
   const styles = style({
     backgroundColor: `${theme.accentBright}`,

--- a/src/pages/education/EducationComponent.js
+++ b/src/pages/education/EducationComponent.js
@@ -6,9 +6,17 @@ import Certifications from "../../containers/certifications/Certifications";
 import EducationImg from "./EducationImg";
 import "./EducationComponent.css";
 import { Fade } from "react-reveal";
+import usePageMetadata from "../usePageMetadata";
 
 function Education(props) {
   const theme = props.theme;
+
+  usePageMetadata({
+    title: "Education | Shubham Mathur",
+    description:
+      "Learn about Shubham Mathur's education background and certifications in technology and software development.",
+    path: "/education",
+  });
   return (
     <div className="education-main">
       <Header theme={props.theme} setTheme={props.setTheme} />

--- a/src/pages/experience/Experience.js
+++ b/src/pages/experience/Experience.js
@@ -6,9 +6,17 @@ import "./Experience.css";
 import { experience } from "../../portfolio.js";
 import { Fade } from "react-reveal";
 import ExperienceImg from "./ExperienceImg";
+import usePageMetadata from "../usePageMetadata";
 
 function Experience(props) {
   const theme = props.theme;
+
+  usePageMetadata({
+    title: "Experience | Shubham Mathur",
+    description:
+      "Review Shubham Mathur's professional experience in software engineering, architecture, and product delivery.",
+    path: "/experience",
+  });
   return (
     <div className="experience-main">
       <Header theme={theme} setTheme={props.setTheme} />

--- a/src/pages/home/HomeComponent.js
+++ b/src/pages/home/HomeComponent.js
@@ -3,8 +3,16 @@ import Header from "../../components/header/Header";
 import Greeting from "../../containers/greeting/Greeting";
 import Skills from "../../containers/skills/Skills";
 import Footer from "../../components/footer/Footer";
+import usePageMetadata from "../usePageMetadata";
 
 function Home(props) {
+  usePageMetadata({
+    title: "Shubham Mathur | Portfolio",
+    description:
+      "Full Stack Developer, Data Analytics & ETL Expert, and Blockchain Enthusiast.",
+    path: "/",
+  });
+
   return (
     <div>
       <Header theme={props.theme} setTheme={props.setTheme} />

--- a/src/pages/projects/Projects.js
+++ b/src/pages/projects/Projects.js
@@ -7,9 +7,17 @@ import { projectsHeader, projects } from "../../portfolio.js";
 import "./Projects.css";
 import ProjectsImg from "./ProjectsImg";
 import { style } from "glamor";
+import usePageMetadata from "../usePageMetadata";
 
 function Projects(props) {
   const theme = props.theme;
+
+  usePageMetadata({
+    title: "Projects | Shubham Mathur",
+    description:
+      "Explore selected projects built by Shubham Mathur across web, cloud, and blockchain domains.",
+    path: "/projects",
+  });
 
   const styles = style({
     backgroundColor: `${theme.accentBright}`,

--- a/src/pages/splash/Splash.js
+++ b/src/pages/splash/Splash.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import "./Splash.css";
 import { Navigate } from "react-router-dom";
+import usePageMetadata from "../usePageMetadata";
 
 function AnimatedSplash(props) {
   return (
@@ -20,6 +21,13 @@ function AnimatedSplash(props) {
 
 function Splash(props) {
   const [redirect, setRedirect] = useState(false);
+
+  usePageMetadata({
+    title: "Welcome | Shubham Mathur",
+    description:
+      "Loading Shubham Mathur's portfolio with projects, experience, and contact details.",
+    path: "/splash",
+  });
   setTimeout(() => setRedirect(true), 1000);
 
   return redirect ? (

--- a/src/pages/usePageMetadata.js
+++ b/src/pages/usePageMetadata.js
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+
+const DEFAULT_SITE_NAME = "Shubham Mathur Portfolio";
+const DEFAULT_LOCALE = "en_US";
+const BASE_URL = "https://shubham-mathur.me";
+const DEFAULT_IMAGE = "/social-preview.svg";
+
+function upsertMeta(selector, attributes) {
+  let element = document.head.querySelector(selector);
+
+  if (!element) {
+    element = document.createElement("meta");
+    if (attributes.name) {
+      element.setAttribute("name", attributes.name);
+    }
+    if (attributes.property) {
+      element.setAttribute("property", attributes.property);
+    }
+    document.head.appendChild(element);
+  }
+
+  element.setAttribute("content", attributes.content);
+}
+
+function upsertLink(selector, attributes) {
+  let element = document.head.querySelector(selector);
+
+  if (!element) {
+    element = document.createElement("link");
+    if (attributes.rel) {
+      element.setAttribute("rel", attributes.rel);
+    }
+    document.head.appendChild(element);
+  }
+
+  element.setAttribute("href", attributes.href);
+}
+
+export default function usePageMetadata({
+  title,
+  description,
+  path,
+  image = DEFAULT_IMAGE,
+}) {
+  useEffect(() => {
+    const canonicalUrl = `${BASE_URL}${path}`;
+    const imageUrl = image.startsWith("http") ? image : `${BASE_URL}${image}`;
+
+    document.title = title;
+
+    upsertMeta('meta[name="description"]', {
+      name: "description",
+      content: description,
+    });
+
+    upsertMeta('meta[property="og:title"]', {
+      property: "og:title",
+      content: title,
+    });
+    upsertMeta('meta[property="og:description"]', {
+      property: "og:description",
+      content: description,
+    });
+    upsertMeta('meta[property="og:url"]', {
+      property: "og:url",
+      content: canonicalUrl,
+    });
+    upsertMeta('meta[property="og:image"]', {
+      property: "og:image",
+      content: imageUrl,
+    });
+    upsertMeta('meta[property="og:site_name"]', {
+      property: "og:site_name",
+      content: DEFAULT_SITE_NAME,
+    });
+    upsertMeta('meta[property="og:locale"]', {
+      property: "og:locale",
+      content: DEFAULT_LOCALE,
+    });
+
+    upsertMeta('meta[name="twitter:title"]', {
+      name: "twitter:title",
+      content: title,
+    });
+    upsertMeta('meta[name="twitter:description"]', {
+      name: "twitter:description",
+      content: description,
+    });
+    upsertMeta('meta[name="twitter:image"]', {
+      name: "twitter:image",
+      content: imageUrl,
+    });
+    upsertMeta('meta[name="twitter:card"]', {
+      name: "twitter:card",
+      content: "summary_large_image",
+    });
+
+    upsertLink('link[rel="canonical"]', {
+      rel: "canonical",
+      href: canonicalUrl,
+    });
+  }, [description, image, path, title]);
+}


### PR DESCRIPTION
### Motivation
- Improve search engine and social sharing appearance by adding standard `robots`, Open Graph and Twitter metadata and a canonical URL for the chosen domain. 
- Provide high-quality social preview media so shares show a consistent branded image across platforms. 
- Support SPA routing by enabling per-route titles/descriptions/OG/Twitter updates so each page (Home, Projects, Experience, etc.) can present distinct metadata.

### Description
- Normalize HTML metadata in `public/index.html` by adding `meta name="robots" content="index,follow,max-image-preview:large"`, `og:description`, `og:image`, `og:site_name`, `og:locale`, `twitter:card` and Twitter title/description/image, and a canonical link to `https://shubham-mathur.me/`.
- Add a single 1200x630 social preview asset at `public/social-preview.svg` and reference it from OG/Twitter tags using the absolute site URL.
- Add a reusable hook `src/pages/usePageMetadata.js` that upserts `title`, `description`, Open Graph, Twitter and canonical tags at runtime; it defaults to `DEFAULT_IMAGE = "/social-preview.svg"` and `BASE_URL = "https://shubham-mathur.me"`.
- Wire the hook into SPA page components so page-level metadata is set for `src/pages/home/HomeComponent.js`, `src/pages/projects/Projects.js`, `src/pages/experience/Experience.js`, `src/pages/education/EducationComponent.js`, `src/pages/contact/ContactComponent.js`, and `src/pages/splash/Splash.js`.

### Testing
- Ran a production build with `yarn build`, which completed successfully and produced the `dist/` output. 
- Pre-commit formatting tasks ran (via the repository hooks) as part of the commit process and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d666d18f88329aee1d5c8224257e6)