### PR TITLE
Align PWA manifest branding with site metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
       property="og:image"
       content="https://shubham-mathur.me/social-preview.svg"
     />
-    <meta property="og:site_name" content="Shubham Mathur Portfolio" />
+    <meta property="og:site_name" content="Shubham Mathur | Portfolio" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Shubham Mathur | Portfolio" />
@@ -134,7 +134,7 @@
           },
           {
             "@type": "WebSite",
-            "name": "Shubham Mathur Portfolio",
+            "name": "Shubham Mathur | Portfolio",
             "url": "https://shubham-mathur.me/"
           }
         ]

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"Shubham Mathur | Portfolio","short_name":"Shubham Portfolio","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#000000","background_color":"#ffffff","display":"standalone"}

--- a/src/pages/usePageMetadata.js
+++ b/src/pages/usePageMetadata.js
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-const DEFAULT_SITE_NAME = "Shubham Mathur Portfolio";
+const DEFAULT_SITE_NAME = "Shubham Mathur | Portfolio";
 const DEFAULT_LOCALE = "en_US";
 const BASE_URL = "https://shubham-mathur.me";
 const DEFAULT_IMAGE = "/social-preview.svg";


### PR DESCRIPTION
### Motivation
- Ensure the PWA manifest contains meaningful branding and that runtime and static metadata are consistent with the site `<title>` and structured data.
- Make the manifest colors match the site's theme so installations and UI chrome use the correct brand color.

### Description
- Updated `public/site.webmanifest` to set `name` to `Shubham Mathur | Portfolio`, `short_name` to `Shubham Portfolio`, `theme_color` to `#000000`, and left `background_color` as `#ffffff` while keeping the existing icon entries.
- Aligned static page metadata by updating `og:site_name` and the `WebSite` structured-data `name` in `public/index.html` to `Shubham Mathur | Portfolio` to match the page `<title>`.
- Updated the runtime metadata default `DEFAULT_SITE_NAME` in `src/pages/usePageMetadata.js` to `Shubham Mathur | Portfolio` so dynamically injected metadata matches the static metadata and manifest.

### Testing
- Parsed `public/site.webmanifest` as JSON and confirmed the manifest `name`, `short_name`, `theme_color`, and `background_color` values were updated as expected.
- Verified referenced icon files exist at `public/android-chrome-192x192.png` and `public/android-chrome-512x512.png`.
- Searched for branding strings across `public/site.webmanifest`, `public/index.html`, and `src/pages/usePageMetadata.js` to confirm consistent usage of `Shubham Mathur | Portfolio`.
- Ran repository linters/formatters (pre-commit hooks) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6c8b47f08329959f4f93326b6074)